### PR TITLE
Add php5-mcrypt to build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 COPY sources.list /etc/apt/
 
 # set install packages as variable
-ENV APTLIST="git-core php5-apcu php5-gd php5-json php5-mysqlnd php5-pgsql"
+ENV APTLIST="git-core php5-apcu php5-gd php5-json php5-mysqlnd php5-pgsql php5-mcrypt"
 
 # install packages
 RUN apt-get update && \
@@ -19,7 +19,10 @@ $APTLIST -qy && \
 
 # cleanup
 apt-get clean -y && \
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+
+#enable mcrypt
+php5enmod mcrypt
 
 # add some files
 ADD defaults/ /defaults/


### PR DESCRIPTION
php5-mcrypt is an optional dependency for TT-RSS that allows encrypting stored usernames/passwords in the database using the option FEED_CRYPT_KEY, rather then storing them in plain text. This PR installs php5-mcrypt and enables the module.