### PR TITLE
Fix issues 16 & 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ RUN \
 	php7-posix \
 	tar && \
  echo "**** link php7 to php ****" && \
- ln -sf /usr/bin/php7 /usr/bin/php
+ ln -sf /usr/bin/php7 /usr/bin/php && \
+ echo "**** download ttrss ****" && \
+ mkdir -p /var/www/html && \
+ curl -o /tmp/tt-rss.tar.gz -L https://git.tt-rss.org/git/tt-rss/archive/master.tar.gz && \
+ tar xf /tmp/tt-rss.tar.gz -C /var/www/html/ --strip-components=1 && \
+ rm /tmp/tt-rss.tar.gz
 
 # copy local files
 COPY root/ /

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it tt-rss /bin/bash`.
 
+### Configure TT-RSS
+
+You can also inject any variable found in config.php using environment variables.
+
+For example, to start with a pre-configured instance, you can use :
+
+* `-e DB_TYPE=pgsql`
+* `-e DB_HOST=localhost`
+* `-e DB_USER=fox`
+* `-e DB_NAME=fox`
+* `-e DB_PASS=XXXXXX`
+* `-e DB_PORT=5432`
+* `-e SELF_URL_PATH=http://example.org/tt-rss/`
+
 ### User / Group Identifiers
 
 Sometimes when using data volumes (`-v` flags) permissions issues can arise between the host OS and the container. We avoid this issue by allowing you to specify the user `PUID` and group `PGID`. Ensure the data volume directory on the host is owned by the same user you specify and it will "just work" ™.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ You must create a user and database for tt-rss to use in a mysql/mariadb or post
 
 A basic nginx configuration file can be found in /config/nginx/site-confs , edit the file to enable ssl (port 443 by default), set servername etc.. Self-signed keys are generated the first time you run the container and can be found in /config/keys , if needed, you can replace them with your own.
 
-The site files are in /config/www/tt-rss , you can find config files and themes folder there. Email and other settings are in the config.php file.
+Some site files are available in /config/www/tt-rss :
+
+* config.php, to change Database, email and other settings
+* plugin.local, to inject your custom plugins
+* theme.local, to inject your custom themes
 
 ## Info
 

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,6 +1,6 @@
 server {
 	listen 80 default_server;
-	root /config/www/tt-rss;
+	root /var/www/html;
 	index index.html index.htm index.php;
 
 	server_name _;

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -1,14 +1,23 @@
 #!/usr/bin/with-contenv bash
 
-# install tt-rss
-if [ ! -d /config/www/tt-rss ]; then
-mkdir -p /config/www/tt-rss
-echo "fetching tt-rss files, this may take a little while"
-curl -o /tmp/test.tar.gz -L https://git.tt-rss.org/git/tt-rss/archive/master.tar.gz
-tar xf /tmp/test.tar.gz -C /config/www/tt-rss --strip-components=1
-rm /tmp/test.tar.gz
-fi
+# create directory structure
+mkdir -p \
+/config/www/tt-rss/{themes.local,plugins.local}
+
+# create symlinks
+symlinks=( \
+/var/www/html/config.php \
+/var/www/html/themes.local \
+/var/www/html/plugins.local
+)
+
+for i in "${symlinks[@]}"
+do
+[[ -e "$i" && ! -L "$i" ]] && rm -rf "$i"
+[[ ! -L "$i" ]] && ln -s /config/www/tt-rss/"$(basename "$i")" "$i"
+done
 
 # permissions
 chown -R abc:abc \
-	/config/www
+	/config/www \
+    /var/www/

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -17,6 +17,51 @@ do
 [[ ! -L "$i" ]] && ln -s /config/www/tt-rss/"$(basename "$i")" "$i"
 done
 
+
+# config.php file setup
+if [ "${DB_USER}" ];
+	then
+	echo "DB_USER set, injecting TT-RSS config"
+
+    if [ ! -f /config/www/tt-rss/config.php ];
+        then
+	    echo "Creating config.php from the dist file"
+        cp /var/www/html/config.php-dist /config/www/tt-rss/config.php
+    fi
+
+    [[ "${DB_TYPE}" ]] && sed -i "s|\s*define('DB_TYPE',.*|\tdefine('DB_TYPE', '$DB_TYPE');|g" /config/www/tt-rss/config.php
+    [[ "${DB_HOST}" ]] && sed -i "s|\s*define('DB_HOST',.*|\tdefine('DB_HOST', '$DB_HOST');|g" /config/www/tt-rss/config.php
+    [[ "${DB_USER}" ]] && sed -i "s|\s*define('DB_USER',.*|\tdefine('DB_USER', '$DB_USER');|g" /config/www/tt-rss/config.php
+    [[ "${DB_NAME}" ]] && sed -i "s|\s*define('DB_NAME',.*|\tdefine('DB_NAME', '$DB_NAME');|g" /config/www/tt-rss/config.php
+    [[ "${DB_PASS}" ]] && sed -i "s|\s*define('DB_PASS',.*|\tdefine('DB_PASS', '$DB_PASS');|g" /config/www/tt-rss/config.php
+    [[ "${DB_PORT}" ]] && sed -i "s|\s*define('DB_PORT',.*|\tdefine('DB_PORT', '$DB_PORT');|g" /config/www/tt-rss/config.php
+    [[ "${MYSQL_CHARSET}" ]] && sed -i "s|\s*define('MYSQL_CHARSET',.*|\tdefine('MYSQL_CHARSET', '$MYSQL_CHARSET');|g" /config/www/tt-rss/config.php
+    [[ "${SELF_URL_PATH}" ]] && sed -i "s|\s*define('SELF_URL_PATH',.*|\tdefine('SELF_URL_PATH', '$SELF_URL_PATH');|g" /config/www/tt-rss/config.php
+    [[ "${SINGLE_USER_MODE}" ]] && sed -i "s|\s*define('SINGLE_USER_MODE',.*|\tdefine('SINGLE_USER_MODE', '$SINGLE_USER_MODE');|g" /config/www/tt-rss/config.php
+    [[ "${SIMPLE_UPDATE_MODE}" ]] && sed -i "s|\s*define('SIMPLE_UPDATE_MODE',.*|\tdefine('SIMPLE_UPDATE_MODE', '$SIMPLE_UPDATE_MODE');|g" /config/www/tt-rss/config.php
+    [[ "${PHP_EXECUTABLE}" ]] && sed -i "s|\s*define('PHP_EXECUTABLE',.*|\tdefine('PHP_EXECUTABLE', '$PHP_EXECUTABLE');|g" /config/www/tt-rss/config.php
+    [[ "${LOCK_DIRECTORY}" ]] && sed -i "s|\s*define('LOCK_DIRECTORY',.*|\tdefine('LOCK_DIRECTORY', '$LOCK_DIRECTORY');|g" /config/www/tt-rss/config.php
+    [[ "${CACHE_DIR}" ]] && sed -i "s|\s*define('CACHE_DIR',.*|\tdefine('CACHE_DIR', '$CACHE_DIR');|g" /config/www/tt-rss/config.php
+    [[ "${ICONS_DIR}" ]] && sed -i "s|\s*define('ICONS_DIR',.*|\tdefine('ICONS_DIR', '$ICONS_DIR');|g" /config/www/tt-rss/config.php
+    [[ "${ICONS_URL}" ]] && sed -i "s|\s*define('ICONS_URL',.*|\tdefine('ICONS_URL', '$ICONS_URL');|g" /config/www/tt-rss/config.php
+    [[ "${AUTH_AUTO_CREATE}" ]] && sed -i "s|\s*define('AUTH_AUTO_CREATE',.*|\tdefine('AUTH_AUTO_CREATE', '$AUTH_AUTO_CREATE');|g" /config/www/tt-rss/config.php
+    [[ "${AUTH_AUTO_LOGIN}" ]] && sed -i "s|\s*define('AUTH_AUTO_LOGIN',.*|\tdefine('AUTH_AUTO_LOGIN', '$AUTH_AUTO_LOGIN');|g" /config/www/tt-rss/config.php
+    [[ "${FORCE_ARTICLE_PURGE}" ]] && sed -i "s|\s*define('FORCE_ARTICLE_PURGE',.*|\tdefine('FORCE_ARTICLE_PURGE', '$FORCE_ARTICLE_PURGE');|g" /config/www/tt-rss/config.php
+    [[ "${SPHINX_SERVER}" ]] && sed -i "s|\s*define('SPHINX_SERVER',.*|\tdefine('SPHINX_SERVER', '$SPHINX_SERVER');|g" /config/www/tt-rss/config.php
+    [[ "${SPHINX_INDEX}" ]] && sed -i "s|\s*define('SPHINX_INDEX',.*|\tdefine('SPHINX_INDEX', '$SPHINX_INDEX');|g" /config/www/tt-rss/config.php
+    [[ "${ENABLE_REGISTRATION}" ]] && sed -i "s|\s*define('ENABLE_REGISTRATION',.*|\tdefine('ENABLE_REGISTRATION', '$ENABLE_REGISTRATION');|g" /config/www/tt-rss/config.php
+    [[ "${REG_NOTIFY_ADDRESS}" ]] && sed -i "s|\s*define('REG_NOTIFY_ADDRESS',.*|\tdefine('REG_NOTIFY_ADDRESS', '$REG_NOTIFY_ADDRESS');|g" /config/www/tt-rss/config.php
+    [[ "${REG_MAX_USERS}" ]] && sed -i "s|\s*define('REG_MAX_USERS',.*|\tdefine('REG_MAX_USERS', '$REG_MAX_USERS');|g" /config/www/tt-rss/config.php
+    [[ "${SESSION_COOKIE_LIFETIME}" ]] && sed -i "s|\s*define('SESSION_COOKIE_LIFETIME',.*|\tdefine('SESSION_COOKIE_LIFETIME', '$SESSION_COOKIE_LIFETIME');|g" /config/www/tt-rss/config.php
+    [[ "${SMTP_FROM_NAME}" ]] && sed -i "s|\s*define('SMTP_FROM_NAME',.*|\tdefine('SMTP_FROM_NAME', '$SMTP_FROM_NAME');|g" /config/www/tt-rss/config.php
+    [[ "${SMTP_FROM_ADDRESS}" ]] && sed -i "s|\s*define('SMTP_FROM_ADDRESS',.*|\tdefine('SMTP_FROM_ADDRESS', '$SMTP_FROM_ADDRESS');|g" /config/www/tt-rss/config.php
+    [[ "${DIGEST_SUBJECT}" ]] && sed -i "s|\s*define('DIGEST_SUBJECT',.*|\tdefine('DIGEST_SUBJECT', '$DIGEST_SUBJECT');|g" /config/www/tt-rss/config.php
+    [[ "${CHECK_FOR_UPDATES}" ]] && sed -i "s|\s*define('CHECK_FOR_UPDATES',.*|\tdefine('CHECK_FOR_UPDATES', '$CHECK_FOR_UPDATES');|g" /config/www/tt-rss/config.php
+    [[ "${ENABLE_GZIP_OUTPUT}" ]] && sed -i "s|\s*define('ENABLE_GZIP_OUTPUT',.*|\tdefine('ENABLE_GZIP_OUTPUT', '$ENABLE_GZIP_OUTPUT');|g" /config/www/tt-rss/config.php
+    [[ "${PLUGINS}" ]] && sed -i "s|\s*define('PLUGINS',.*|\tdefine('PLUGINS', '$PLUGINS');|g" /config/www/tt-rss/config.php
+    [[ "${LOG_DESTINATION}" ]] && sed -i "s|\s*define('LOG_DESTINATION',.*|\tdefine('LOG_DESTINATION', '$LOG_DESTINATION');|g" /config/www/tt-rss/config.php
+fi
+
 # permissions
 chown -R abc:abc \
 	/config/www \

--- a/root/etc/cont-init.d/60-create-db
+++ b/root/etc/cont-init.d/60-create-db
@@ -1,0 +1,67 @@
+#!/usr/bin/with-contenv php
+<?php
+
+// Based on https://git.tt-rss.org/fox/tt-rss/src/master/install/index.php
+// For the case $op == 'installschema'
+
+function pdo_connect($host, $user, $pass, $db, $type, $port = false) {
+
+    $db_port = $port ? ';port=' . $port : '';
+    $db_host = $host ? ';host=' . $host : '';
+
+    try {
+        $pdo = new PDO($type . ':dbname=' . $db . $db_host . $db_port,
+            $user,
+            $pass);
+
+        return $pdo;
+    } catch (Exception $e) {
+        echo "Unable to connect to database using specified parameters : " .  $e->getMessage() . PHP_EOL;
+        return null;
+    }
+}
+
+if (file_exists("/config/www/tt-rss/config.php")) {
+    echo "Loading config.php" . PHP_EOL;
+    require_once "/config/www/tt-rss/config.php";
+
+    $pdo = pdo_connect(DB_HOST, DB_USER, DB_PASS, DB_NAME, DB_TYPE, DB_PORT);
+    if (!$pdo) {
+        exit(2);
+    }
+    echo "Connected to the database" . PHP_EOL;
+
+    $res = $pdo->query("SELECT true FROM ttrss_feeds");
+    if ($res && $res->fetch()) {
+        echo "Some tt-rss data already exists in this database, skipping database installation" . PHP_EOL;
+        exit(0);
+    }
+    echo "tt-rss data not found, initializing the database" . PHP_EOL;
+
+    $lines = explode(";", preg_replace("/[\r\n]/", "",
+        file_get_contents("/var/www/html/schema/ttrss_schema_".basename(DB_TYPE).".sql")));
+
+    $dbInitError = 0;
+    foreach ($lines as $line) {
+        if (strpos($line, "--") !== 0 && $line) {
+            $res = $pdo->query($line);
+
+            if (!$res) {
+                echo "Query: $line" . PHP_EOL;
+                echo "Error: " . implode(", ", $this->pdo->errorInfo()) . PHP_EOL;
+                $dbInitError++;
+            }
+        }
+    }
+
+    if($dbInitError == 0) {
+        echo "Database initialization completed." . PHP_EOL;
+        exit(0);
+    } else {
+        echo "Database initialization failed." . PHP_EOL;
+        exit(1);
+    }
+}
+else {
+    echo "config.php absent, please use the installer or manually edit /config/www/tt-rss/config.php to finish the installation" . PHP_EOL;
+}

--- a/root/etc/services.d/update-feeds/run
+++ b/root/etc/services.d/update-feeds/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 	s6-setuidgid abc php7 \
-	/config/www/tt-rss/update_daemon2.php > /dev/null 2>&1
+	/var/www/html/update_daemon2.php > /dev/null 2>&1


### PR DESCRIPTION
I've tried to improve how the image is build and how the container is initialized to fix the 2 issues I've opened : 
* closes #16 
* closes #17 

I've mostly copied how [docker-bookstack](https://github.com/linuxserver/docker-bookstack/) works.

A few notes however.

1. Previously, the whole TT-RSS folder was available under the /config volume.

In this PR, I've changed this to keep TT-RSS inside the docker image, and only link a few files in the /config volume.
I've included the themes.local and plugins.local folders for customizations, and config.php.
I'm assuming the large majority of users would only change these files.

However, if some users were customizing other files, they won't be able to anymore. 

2. Injecting configurations in config.php is easy.

However, that's not really planned for in TT-RSS' setup process.
If the config.php file is present, the installer is blocked (which makes sense). But that's the only way to initialize the database.

I didn't find any other way than to write a small PHP script that executes the same SQL file as the intaller.

Feel free to raise any question or concern you might have about this PR.