### PR TITLE
Added LDAP and replaced curl/tar with git.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="sparklyballs"
 RUN \
  echo "**** install packages ****" && \
  apk add --no-cache \
-	curl \
+	git \
 	php7-apcu \
 	php7-curl \
 	php7-dom \
@@ -24,7 +24,7 @@ RUN \
 	php7-pdo_pgsql \
 	php7-pgsql \
 	php7-posix \
-	tar && \
+	php7-ldap && \
  echo "**** link php7 to php ****" && \
  ln -sf /usr/bin/php7 /usr/bin/php
 

--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -4,9 +4,7 @@
 if [ ! -d /config/www/tt-rss ]; then
 mkdir -p /config/www/tt-rss
 echo "fetching tt-rss files, this may take a little while"
-curl -o /tmp/test.tar.gz -L https://git.tt-rss.org/git/tt-rss/archive/master.tar.gz
-tar xf /tmp/test.tar.gz -C /config/www/tt-rss --strip-components=1
-rm /tmp/test.tar.gz
+git clone https://gitlab.com/gothfox/tt-rss.git /config/www/tt-rss
 fi
 
 # permissions


### PR DESCRIPTION
The current method of using `curl`/`tar` for installing TT-RSS does not allow for updating. In an ideal world, updating at build time would be best, however the design of TT-RSS makes this difficult (see https://github.com/linuxserver/docker-tt-rss/issues/16).

To address https://github.com/linuxserver/docker-tt-rss/issues/16, this PR replaces curl/tar with a `git clone` of the GitLab mirror (fastest mirror). This allows users to run a `git pull` to update, and enable the auto-updates from the `config.php` file.

Also, I have included `php7-ldap` to address https://github.com/linuxserver/docker-tt-rss/issues/20 as well. This has been tested and functions in in my environment.

Note: This is my `master` branch, however I will make no other edits until merge.
