### PR TITLE
fix for supporting upgrades with in container install

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,6 @@ In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as bel
 
 You must create a user and database for tt-rss to use in a mysql/mariadb or postgresql server. A basic nginx configuration file can be found in /config/nginx/site-confs , edit the file to enable ssl (port 443 by default), set servername etc.. Self-signed keys are generated the first time you run the container and can be found in /config/keys , if needed, you can replace them with your own.
 
-After you run the initial setup for this application from the `/install/` web directory a config.php will be generated inside the container. To have access to this file in /config/config.php you will need to restart the container using:
-```
-docker restart tt-rss
-```
-
 **The default username and password after initial configuration is admin/password**
 
 ## Power users

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,11 +46,6 @@ app_setup_block_enabled: true
 app_setup_block: |
   You must create a user and database for tt-rss to use in a mysql/mariadb or postgresql server. A basic nginx configuration file can be found in /config/nginx/site-confs , edit the file to enable ssl (port 443 by default), set servername etc.. Self-signed keys are generated the first time you run the container and can be found in /config/keys , if needed, you can replace them with your own.
 
-  After you run the initial setup for this application from the `/install/` web directory a config.php will be generated inside the container. To have access to this file in /config/config.php you will need to restart the container using:
-  ```
-  docker restart tt-rss
-  ```
-  
   **The default username and password after initial configuration is admin/password**
 
   ## Power users

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -15,6 +15,8 @@ symlinks=( \
 )
 
 for i in "${symlinks[@]}"; do
+	[[ "$(basename "$i")" == "config.php" && -e /config/"$(basename "$i")" && ! -L "$i" ]] && \
+		ln -s /config/"$(basename "$i")" "$i"
 	[[ -e "$i" && ! -L "$i" && -e /config/"$(basename "$i")" ]] && \
 		rm -Rf "$i" && \
 		ln -s /config/"$(basename "$i")" "$i"

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -15,7 +15,7 @@ symlinks=( \
 )
 
 for i in "${symlinks[@]}"; do
-	[[ "$(basename "$i")" == "config.php" && -e /config/"$(basename "$i")" && ! -L "$i" ]] && \
+	[[ "$(basename "$i")" == "config.php" && ! -L "$i" ]] && \
 		ln -s /config/"$(basename "$i")" "$i"
 	[[ -e "$i" && ! -L "$i" && -e /config/"$(basename "$i")" ]] && \
 		rm -Rf "$i" && \


### PR DESCRIPTION
https://github.com/linuxserver/docker-tt-rss/issues/27

The logic never took into account on container replacement the file would not be present. Need a specific guard for just that scenario. 