### PR TITLE
Add _FILE variants for DB_USER and DB_PASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You must create a user and database for tt-rss to use in a mysql/mariadb or post
 **The default username and password after initial configuration is admin/password**
 
 ## Power users
-The container can configure itself using environment variables, the gaurd for this logic to run is if the variable `DB_TYPE` is set. The most common variables to set are a URL for the application and a database endpoint. IE:
+The container can configure itself using environment variables, the guard for this logic to run is if the variable `DB_TYPE` is set. The most common variables to set are a URL for the application and a database endpoint. IE:
 * -e DB_TYPE=mysql
 * -e DB_HOST=host
 * -e DB_USER=user
@@ -142,6 +142,10 @@ The container can configure itself using environment variables, the gaurd for th
 * -e DB_PASS=password
 * -e DB_PORT=3306
 * -e SELF_URL_PATH=http://localhost/
+
+DB_PASS and DB_USER also have _FILE variants which will read the contents of a file instead. _FILE variants are prioritised if present.
+* -e DB_USER_FILE=/path/to/userfile
+* -e DB_PASS_FILE=/path/to/passfile
 
 Please note if you use this method you need to have an already initialized database endpoint. We do our best to ensure that anything in the config.php can be set via these environment variables. 
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -52,7 +52,7 @@ app_setup_block: |
   **The default username and password after initial configuration is admin/password**
 
   ## Power users
-  The container can configure itself using environment variables, the gaurd for this logic to run is if the variable `DB_TYPE` is set. The most common variables to set are a URL for the application and a database endpoint. IE:
+  The container can configure itself using environment variables, the guard for this logic to run is if the variable `DB_TYPE` is set. The most common variables to set are a URL for the application and a database endpoint. IE:
   * -e DB_TYPE=mysql
   * -e DB_HOST=host
   * -e DB_USER=user
@@ -60,6 +60,10 @@ app_setup_block: |
   * -e DB_PASS=password
   * -e DB_PORT=3306
   * -e SELF_URL_PATH=http://localhost/
+  
+  DB_PASS and DB_USER also have _FILE variants which will read the contents of a file instead. _FILE variants are prioritised if present.
+  * -e DB_USER_FILE=/path/to/userfile
+  * -e DB_PASS_FILE=/path/to/passfile
 
   Please note if you use this method you need to have an already initialized database endpoint. We do our best to ensure that anything in the config.php can be set via these environment variables. 
 

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -36,8 +36,10 @@ if [ "${DB_TYPE+x}" ]; then
 	[[ "${DB_TYPE+x}" ]] && sed -i "s|\s*define('DB_TYPE',.*|\tdefine('DB_TYPE', '$DB_TYPE');|g" /config/config.php
 	[[ "${DB_HOST+x}" ]] && sed -i "s|\s*define('DB_HOST',.*|\tdefine('DB_HOST', '$DB_HOST');|g" /config/config.php
 	[[ "${DB_USER+x}" ]] && sed -i "s|\s*define('DB_USER',.*|\tdefine('DB_USER', '$DB_USER');|g" /config/config.php
+  [[ "${DB_USER_FILE+x}" ]] && sed -i "s|\s*define('DB_USER',.*|\tdefine('DB_USER', '$(cat $DB_USER_FILE)');|g" /config/config.php
 	[[ "${DB_NAME+x}" ]] && sed -i "s|\s*define('DB_NAME',.*|\tdefine('DB_NAME', '$DB_NAME');|g" /config/config.php
 	[[ "${DB_PASS+x}" ]] && sed -i "s|\s*define('DB_PASS',.*|\tdefine('DB_PASS', '$DB_PASS');|g" /config/config.php
+ 	[[ "${DB_PASS_FILE+x}" ]] && sed -i "s|\s*define('DB_PASS',.*|\tdefine('DB_PASS', '$(cat $DB_PASS_FILE)');|g" /config/config.php
 	[[ "${DB_PORT+x}" ]] && sed -i "s|\s*define('DB_PORT',.*|\tdefine('DB_PORT', '$DB_PORT');|g" /config/config.php
 	[[ "${MYSQL_CHARSET+x}" ]] && sed -i "s|\s*define('MYSQL_CHARSET',.*|\tdefine('MYSQL_CHARSET', '$MYSQL_CHARSET');|g" /config/config.php
 	[[ "${SELF_URL_PATH+x}" ]] && sed -i "s|\s*define('SELF_URL_PATH',.*|\tdefine('SELF_URL_PATH', '$SELF_URL_PATH');|g" /config/config.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->
### What does it do?
Uses the content of the file at DB_{USER||PASS}\_FILE to load into config. Overrides any value given by DB_{USER|PASS} if present.

### Why is this needed?
Docker secrets, kubernetes secrets, other secrets implementations.
Allows you to avoid loading secrets into environment variables.

